### PR TITLE
Add XYZ coordinates into admin panel

### DIFF
--- a/client/src/admin/adminPanel.tsx
+++ b/client/src/admin/adminPanel.tsx
@@ -5,6 +5,7 @@ import { animated } from 'react-spring';
 import { PrimaryButton, SecondaryButton } from '../common/button';
 import { TiChevronLeft } from 'react-icons/ti';
 import { Location } from '../common/typeUtil';
+import { geoCoordsToPlaneCoords } from '../location/mqttDeserialize';
 
 const CancelButton = styled(SecondaryButton)`
   border: none;
@@ -156,7 +157,10 @@ const AdminPanel = ({
           <AndroidRow key={'rpi-' + i}>
             <AndroidHeader>{device.name}</AndroidHeader>
             <LocationRow>
-              N {device.lat.toFixed(6)}° E {device.lon.toFixed(6)}°
+              N {device.lat.toFixed(6)}° E {device.lon.toFixed(6)}° x:
+              {geoCoordsToPlaneCoords(device, device.height).x} y:
+              {geoCoordsToPlaneCoords(device, device.height).y} z:
+              {device.height}
             </LocationRow>
           </AndroidRow>
         ))}

--- a/client/src/location/mqttDeserializeTest.ts
+++ b/client/src/location/mqttDeserializeTest.ts
@@ -3,6 +3,7 @@ import Deserializer, {
   BabylonBeacon,
   MqttMessageDecoder,
   mqttMessageToGeo,
+  geoCoordsToPlaneCoords,
 } from './mqttDeserialize';
 import * as t from 'io-ts';
 import { unsafeDecode } from '../common/typeUtil';
@@ -46,7 +47,7 @@ describe('MQTT parsing', () => {
   });
 });
 
-describe('geographic coordinate conversion', () => {
+describe('coordinate conversion into geographic format', () => {
   it('should convert zero coordinates nearby to the origo', () => {
     const input = exampleMqttMessage(1);
     input.x = 0.0;
@@ -69,7 +70,7 @@ describe('geographic coordinate conversion', () => {
     input.y = 41000.0; // length of library wall
 
     const westCorner = {
-      lat: 60.2050688,
+      lat: 60.2050738,
       lon: 24.9615679,
     };
 
@@ -90,5 +91,24 @@ describe('geographic coordinate conversion', () => {
 
     expect(geoCoords.lat).toBeCloseTo(southCorner.lat, 5);
     expect(geoCoords.lon).toBeCloseTo(southCorner.lon, 5);
+  });
+});
+
+describe('coordinate conversion into plane format', () => {
+  it('should return origo for northern corner', () => {
+    const input = { lat: 60.205323, lon: 24.962112 };
+
+    const result = geoCoordsToPlaneCoords(input, 10);
+
+    expect(result.x).toBeCloseTo(0.0);
+  });
+
+  it('should return right coords for java room corner', () => {
+    const input = { lat: 60.205092, lon: 24.96174 };
+
+    const result = geoCoordsToPlaneCoords(input, 10);
+
+    expect(result.y).toBeCloseTo(32662.0972328);
+    expect(result.x).toBeCloseTo(3847.381576);
   });
 });


### PR DESCRIPTION
This is fallback for calibrating the Android device locations manually so that the UI displayes the coordinates in x/y/z format wanted by the server.